### PR TITLE
Removes pkg.m4 from make clean execution

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -198,5 +198,5 @@ CLEANFILES = $(OSX_DMG) $(SILK_WIN_INSTALLER)
 
 clean-local:
 	rm -rf test_silk.coverage/ total.coverage/ $(OSX_APP)
-	rm -f Makefile &&  rm -f *.in && rm -f *.m4 && rm -f configure
+	rm -f Makefile &&  rm -f *.in && rm -f configure
 	rm -f *.status && rm -f libtool && rm -f build-aux/*.*


### PR DESCRIPTION
<!--- Remove sections that do not apply -->


#### What is the purpose of this pull request (PR)?

We do not want to delete pkg.m4 when executing make clean. 


