### PR TITLE
[RPC] Adds getstakereport RPC command 

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2155,6 +2155,173 @@ UniValue makekeypair(const UniValue& params, bool fHelp)
     return result;
 }
 
+// getstakereport
+struct StakePeriodRange_T 
+{
+    int64_t Start;
+    int64_t End;
+    int64_t Total;
+    int Count;
+    string Name;
+};
+
+typedef vector<StakePeriodRange_T> vStakePeriodRange_T;
+
+    // **em52: Get total coins staked on given period
+    // inspired from CWallet::GetStake()
+    // Parameter aRange = Vector with given limit date, and result
+    // return int =  Number of Wallet's elements analyzed
+int GetStakeSubTotal(vStakePeriodRange_T& aRange, const isminefilter filter)
+{
+    int nElement = 0;
+    CAmount nAmount = 0;
+
+    const CWalletTx* pcoin;
+
+    vStakePeriodRange_T::iterator vIt;
+
+    // scan the entire wallet transactions
+    for (map<uint256, CWalletTx>::const_iterator it = pwalletMain->mapWallet.begin();
+         it != pwalletMain->mapWallet.end();
+         ++it)
+    {
+        pcoin = &(*it).second;
+
+        // skip orphan block or immature
+        if  ((!pcoin->GetDepthInMainChain()) || (pcoin->GetBlocksToMaturity()>0))
+            continue;
+
+        // skip transaction other than POS block
+        if (!(pcoin->IsCoinStake()))
+            continue;
+
+        nElement++;
+
+        // use the cached amount if available
+        if (pcoin->fCreditCached && pcoin->fDebitCached)
+            nAmount = pcoin->nCreditCached - pcoin->nDebitCached;
+        else
+            nAmount = pcoin->GetCredit(filter) - pcoin->GetDebit(filter);
+
+        // scan the range
+        for(vIt=aRange.begin(); vIt != aRange.end(); vIt++)
+        {
+            if (pcoin->nTime >= vIt->Start)
+            {
+                if (! vIt->End)
+                {   // Manage Special case
+                    vIt->Start = pcoin->nTime;
+                    vIt->Total = nAmount;
+                }
+                else if (pcoin->nTime <= vIt->End)
+                {
+                    vIt->Count++;
+                    vIt->Total += nAmount;
+                }
+            }
+        }
+
+    }
+    return nElement;
+}
+
+struct tm * localtime_r (const time_t *timer, struct tm *result)
+{
+   struct tm *local_result;
+   local_result = localtime (timer);
+
+   if (local_result == NULL || result == NULL)
+     return NULL;
+
+   memcpy (result, local_result, sizeof (result));
+   return result;
+}
+
+// prepare range for stake report
+vStakePeriodRange_T PrepareRangeForStakeReport()
+{
+    vStakePeriodRange_T aRange;
+    StakePeriodRange_T x;
+
+    struct tm Loc_MidNight;
+
+    int64_t n1Hour = 60*60;
+    int64_t n1Day = 24 * n1Hour;
+
+    int64_t nToday = GetTime();
+    time_t CurTime = nToday;
+
+    localtime_r(&CurTime, &Loc_MidNight);
+    Loc_MidNight.tm_hour = 0;
+    Loc_MidNight.tm_min = 0;
+    Loc_MidNight.tm_sec = 0;  // set midnight
+
+    x.Start = mktime(&Loc_MidNight);
+    x.End   = nToday;
+    x.Count = 0;
+    x.Total = 0;
+
+    // prepare subtotal range of last 24H, 1 week, 30 days, 1 years
+    int GroupDays[4][2] =     { {1 ,0}, {7 ,0 }, {30, 0}, {365, 0}};
+    std::string sGroupName[] = {"24H", "7 Days", "30 Days", "365 Days" };
+
+    nToday = GetTime();
+
+    for(int i=0; i<4; i++)
+    {
+        x.Start = nToday - GroupDays[i][0] * n1Day;
+        x.End   = nToday - GroupDays[i][1] * n1Day;
+        x.Name = "Last " + sGroupName[i];
+
+        aRange.push_back(x);
+    }
+
+    // Special case. not a subtotal, but last stake
+    x.End  = 0;
+    x.Start = 0;
+    x.Name = "Latest Stake";
+    aRange.push_back(x);
+
+    return aRange;
+}
+
+// getstakereport: return SubTotal of the staked coins in last 24H, 7/30/365 days
+UniValue getstakereport(const UniValue& params, bool fHelp)
+{
+    if ((params.size()>0) || (fHelp))
+        throw runtime_error(
+            "getstakereport\n"
+            "List last single 30 day stake subtotal and last 24h, 7, 30, 365 day subtotal.\n");
+
+    vStakePeriodRange_T aRange = PrepareRangeForStakeReport();
+
+    // get subtotal calc
+    int64_t nTook = GetTimeMillis();
+    int nItemCounted = GetStakeSubTotal(aRange, ISMINE_SPENDABLE);
+    nTook = GetTimeMillis() - nTook;
+
+    UniValue result(UniValue::VOBJ);
+
+    vStakePeriodRange_T::iterator vIt;
+
+    // report it
+    for(vIt = aRange.begin(); vIt != aRange.end(); vIt++)
+    {
+        result.push_back(Pair(vIt->Name, FormatMoney(vIt->Total).c_str()));
+    }
+
+    vIt--;
+    result.push_back(Pair("Latest Time",
+       vIt->Start ? DateTimeStrFormat(vIt->Start).c_str() :
+       "Never"));
+
+    // report element counted / time took
+    result.push_back(Pair("Stake counted", nItemCounted));
+    result.push_back(Pair("time took (ms)",  nTook ));
+
+    return  result;
+}
+
 
 extern UniValue dumpprivkey(const UniValue& params, bool fHelp); // in rpcdump.cpp
 extern UniValue importprivkey(const UniValue& params, bool fHelp);
@@ -2194,6 +2361,7 @@ static const CRPCCommand commands[] =
     { "wallet",             "getreceivedbyaddress",   &getreceivedbyaddress,   false,     false,      true },
     { "wallet",             "gettransaction",         &gettransaction,         false,     false,      true },
     { "wallet",             "getunconfirmedbalance",  &getunconfirmedbalance,  false,     false,      true },
+    { "wallet",             "getstakereport",         &getstakereport,         false,     false,      true },
     { "wallet",             "getwalletinfo",          &getwalletinfo,          false,     false,      true },
     { "wallet",             "importprivkey",          &importprivkey,          true,      false,      true },
     { "wallet",             "importwallet",           &importwallet,           true,      false,      true },

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1149,7 +1149,7 @@ CAmount CWalletTx::GetCredit(const isminefilter& filter) const
     if ((IsCoinBase() || IsCoinStake()) && GetBlocksToMaturity() > 0)
         return 0;
 
-    int64_t credit = 0;
+    CAmount credit = 0;
     if (filter & ISMINE_SPENDABLE)
     {
         // GetBalance can assume transactions in mapWallet won't change


### PR DESCRIPTION
<!--- Remove sections that do not apply -->


#### What is the purpose of this pull request (PR)?
This PR adds a new RPC command called getstakereport.


#### Any background context to help the reviewer?
Returns the amount of coins staked in the last 24 hours, last 7 days, last month, and the last year. Also returns amount and time of the latest stake as well as the total amount of blocks staked for the wallet. It also returns the amount of milliseconds that it took to calculate these figures.


#### Was this PR tested and how?
Successfully tested on Ubuntu 16.

