### PR TITLE
Fix stake splitting

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2604,9 +2604,7 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
                 nCredit += pcoin.first->vout[pcoin.second].nValue;
                 vwtxPrev.push_back(pcoin.first);
                 txNew.vout.push_back(CTxOut(0, scriptPubKeyOut));
-                if (nCredit >= GetStakeSplitThreshold())
-                    txNew.vout.push_back(CTxOut(0, txNew.vout[1].scriptPubKey)); //split stake
-
+                
                 LogPrint("coinstake", "CreateCoinStake : added kernel type=%d\n", whichType);
                 fKernelFound = true;
                 break;


### PR DESCRIPTION
#### What is the purpose of this pull request (PR)?
currently stakes that should split do not split and create two empty vouts,
this is due to duplicate checks creating an extra vout which breaks split logic

this pull removes 1 check, enabling the split logic to work properly

example of extra vouts
https://seqexplorer.duality.solutions/api/getrawtransaction?txid=6144ea2f281b3f5b9134e15ba694aad5d437918cafbcf4a5d51e552bc105669a&decrypt=1