### PR TITLE
Remove duplicate 'time' JSON value for transaction

### DIFF
--- a/src/rpc/rpcrawtransaction.cpp
+++ b/src/rpc/rpcrawtransaction.cpp
@@ -56,7 +56,7 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry)
     entry.push_back(Pair("txid", tx.GetHash().GetHex()));
     entry.push_back(Pair("version", tx.nVersion));
     entry.push_back(Pair("locktime", (int64_t)tx.nLockTime));
-    entry.push_back(Pair("time", (int64_t)tx.nTime));
+    entry.push_back(Pair("txtime", (int64_t)tx.nTime));
     UniValue vin(UniValue::VARR);
     for(const CTxIn& txin : tx.vin) {
         UniValue in(UniValue::VOBJ);


### PR DESCRIPTION
- Fixes Duplicate key time error when running Iquidus block explorer.